### PR TITLE
changed metatag assets url from main to play environment

### DIFF
--- a/server/meta/index.js
+++ b/server/meta/index.js
@@ -6,47 +6,47 @@ let meta = {
   '/': {
     title: 'Wallfair.',
     description: 'Betting Reimagined',
-    image: 'https://main.wallfair.io/logo192.png',
+    image: 'https://play.wallfair.io/logo192.png',
     keywords: 'wallfair, casino, betting, esports, crypto',
   },
   '/live-events/all': {
     title: 'Wallfair Live Events',
     description: 'High Energy, Live events',
-    image: 'https://main.wallfair.io/logo192.png',
+    image: 'https://play.wallfair.io/logo192.png',
     keywords: 'wallfair, casino, live, events, betting, esports, gaming',
   },
   '/live-events': {
     title: 'Wallfair Live Events',
     description: 'Fast Paced Live-Events',
-    image: 'https://main.wallfair.io/logo192.png',
+    image: 'https://play.wallfair.io/logo192.png',
     keywords:
       'wallfair, casino, live, events, esports, crypto, gaming, sports, betting',
   },
   '/events/all': {
     title: 'Wallfair Events',
     description: 'Intense, high-paced and hilarious events for everyone',
-    image: 'https://main.wallfair.io/logo192.png',
+    image: 'https://play.wallfair.io/logo192.png',
     keywords:
       'wallfair, casino, events, politics, news, sports, esports, gaming, crypto',
   },
   '/events': {
     title: 'Wallfair Events',
     description: 'Will Harris take the 2024 US Election?',
-    image: 'https://main.wallfair.io/logo192.png',
+    image: 'https://play.wallfair.io/logo192.png',
     keywords:
       'Wallfair, Casino, Events, Harris, Biden, Trump, Crypto, Esports, Sports, Gaming',
   },
   '/games': {
     title: 'Wallfair Games',
     description: 'Earn more with Wallfair games, all day, everyday',
-    image: 'https://main.wallfair.io/logo192.png',
+    image: 'https://play.wallfair.io/logo192.png',
     keywords:
       'wallfair, casino, games betting, vegas, gambling, odds, roulette, crypto-casino',
   },
   '/games/elon-game': {
     title: 'Wallfair Elon Game',
     description: 'To the Moon with Elon, big wins, tiny rocket',
-    image: 'https://main.wallfair.io/rosi-games-banner.png',
+    image: 'https://play.wallfair.io/rosi-games-banner.png',
     keywords:
       'Wallfair, Casino, Games, Elon, Moon, Rocket, Crypto, Casino, Betting',
   },
@@ -108,7 +108,7 @@ module.exports = {
         data['aboutMe'] ||
         'This user has not provided an about info yet. How boring!';
       const photoUrl =
-        data['profilePicture'] || 'https://main.wallfair.io/logo192.png';
+        data['profilePicture'] || 'https://play.wallfair.io/logo192.png';
       const userTag = '/user/' + userId;
       meta[userTag] = {
         title: userName,


### PR DESCRIPTION
Meta tag images were targeting to main.wallfair.io, which has a robots.txt file that is configured to avoid crawlers/bots.
This PR will fix the URLs for the play environment's meta images and will avoid that they are ignored by Twitter, FB, Google and other bots/crawlers.