### PR TITLE
Task/mvp2 754 redesign issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ initTagManager();
 const App = () => {
   const { onScroll, hideNavbar } = useHideMobileScrollingMenu();
   return (
-    <div id={'main-scroll-container'} onScroll={onScroll} style={{overflow:'scroll'}}>
+    <div id={'main-scroll-container'} onScroll={onScroll} style={{ overflow: 'auto' }}>
       <Provider store={store}>
         <PersistGate persistor={persistor}>
           <ConnectedRouter history={history}>

--- a/src/components/ActivitiesTracker/index.js
+++ b/src/components/ActivitiesTracker/index.js
@@ -93,6 +93,7 @@ const ActivitiesTracker = ({
   userId,
   preselectedCategory,
   cleanUpActivities,
+  showBets
 }) => {
   const messageListRef = useRef();
 
@@ -262,7 +263,7 @@ const ActivitiesTracker = ({
             },
           }}
         >
-          {ACTIVITIES_TO_TRACK.map((activity, index) => (
+          {ACTIVITIES_TO_TRACK.filter(x => x.value !== 'bets' || showBets).map((activity, index) => (
             <SwiperSlide key={`swiper-slide-${index}`}>
               <div
                 className={classNames(styles.boxIcon, {

--- a/src/components/Authentication/index.js
+++ b/src/components/Authentication/index.js
@@ -106,10 +106,20 @@ const Authentication = ({
     return passwordConfirmation && password === passwordConfirmation;
   };
 
+  const getAge = (birthDate) => {
+    if(!birthDate) return 0;
+    var today = new Date();
+    var age = today.getFullYear() - birthDate.getFullYear();
+    var m = today.getMonth() - birthDate.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+        age--;
+    }
+    return age;
+}
+
   const birthdayIsValid = () => {
-    const currentYear = new Date().getFullYear();
-    const isOver18 =
-      currentYear - birthYear > 17 && currentYear - birthYear < 100;
+    if(!birthDay || !birthMonth || !birthYear) return false;
+    const isOver18 = getAge(new Date(birthYear, birthMonth-1, birthDay)) >= 18;
     return (
       birthDay >= 1 &&
       birthDay <= 31 &&

--- a/src/components/EventActivitiesTracker/ActivityMessage.js
+++ b/src/components/EventActivitiesTracker/ActivityMessage.js
@@ -12,7 +12,7 @@ import ActivityTableRow from './ActivityTableRow';
 import { roundToTwo } from '../../helper/FormatNumbers';
 import { getGameById } from '../../helper/Games';
 
-const ActivityMessage = ({ activity, users, hideSecondaryColumns }) => {
+const ActivityMessage = ({ activity, users, hideSecondaryColumns, layout }) => {
   const getUserProfileUrl = data => {
     let user = _.get(data, 'user');
     let userId = _.get(user, '_id');
@@ -74,6 +74,7 @@ const ActivityMessage = ({ activity, users, hideSecondaryColumns }) => {
             type={'cashout'}
             gameLabel={gameLabel}
             hideSecondaryColumns={hideSecondaryColumns}
+            layout={layout}
           />
         );
       case 'Casino/EVENT_CASINO_LOST': {
@@ -89,9 +90,10 @@ const ActivityMessage = ({ activity, users, hideSecondaryColumns }) => {
         return (
           <ActivityTableRow
             data={rowData}
-            type={'lost'}
+            type={'cashout'}
             gameLabel={gameLabel}
             hideSecondaryColumns={hideSecondaryColumns}
+            layout={layout}
           />
         );
       }

--- a/src/components/EventActivitiesTracker/ActivityTable.js
+++ b/src/components/EventActivitiesTracker/ActivityTable.js
@@ -4,25 +4,26 @@ import styles from './styles.module.scss';
 import Grid from '@material-ui/core/Grid';
 import ActivityTableRow from './ActivityTableRow';
 
-const ActivityTable = ({ rowData, gameLabel, hideSecondaryColumns = false }) => {
+const ActivityTable = ({ rowData, gameLabel, hideSecondaryColumns = false, layout='compact' }) => {
+  const layoutCss = layout === 'compact' ? styles.compact : null;
   return (
     <div className={styles.activitiesTrackerContainer}>
-      <div className={styles.header}>
-        <Grid container>
+      <div className={classNames(styles.header,layoutCss)}>
+        <Grid container className={styles.flexContainer}>
           <Grid item xs>
-            <p className={styles.titleFirst}>GAME</p>
+            <p className={styles.titleLeft}>GAME</p>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <p className={styles.title}>USER</p>
+            <p className={styles.titleLeft}>USER</p>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <p className={styles.title}>TRADE</p>
+            <p className={styles.titleRight}>TRADE</p>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
             <p className={styles.title}>MULT</p>
           </Grid>
           <Grid item xs >
-            <p className={styles.titleLast}>CASHOUT</p>
+            <p className={styles.titleRight}>CASHOUT</p>
           </Grid>
         </Grid>
       </div>
@@ -34,6 +35,7 @@ const ActivityTable = ({ rowData, gameLabel, hideSecondaryColumns = false }) => 
             data={r}
             gameLabel={gameLabel}
             hideSecondaryColumns={hideSecondaryColumns}
+            layout={layout}
           />
         ))}
       </div>

--- a/src/components/EventActivitiesTracker/ActivityTableRow.js
+++ b/src/components/EventActivitiesTracker/ActivityTableRow.js
@@ -6,6 +6,7 @@ import medalCoin from '../../data/icons/medal-coin.png';
 import { toNumericString } from 'helper/FormatNumbers';
 import classNames from 'classnames';
 import { GAMES } from 'constants/Games';
+import { roundToTwo } from '../../helper/FormatNumbers';
 
 const UserLink = props => {
   const { userId, username } = props;
@@ -54,7 +55,7 @@ const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false 
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
             <div className={styles.messageCenter}>
-              <p className={styles.rewardMulti}>{crashFactor}x</p>
+              <p className={styles.rewardMulti}>{roundToTwo(crashFactor)}x</p>
             </div>
           </Grid>
           <Grid item xs >
@@ -92,7 +93,7 @@ const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false 
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
             <div className={styles.messageCenter}>
-              <p className={styles.rewardMulti}>{crashFactor}x</p>
+              <p className={styles.rewardMulti}>{roundToTwo(crashFactor)}x</p>
             </div>
           </Grid>
           <Grid item xs>

--- a/src/components/EventActivitiesTracker/ActivityTableRow.js
+++ b/src/components/EventActivitiesTracker/ActivityTableRow.js
@@ -22,7 +22,8 @@ const UserLink = props => {
   );
 };
 
-const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false }) => {
+const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false, layout = 'compact'}) => {
+  const layoutCss = layout === 'compact' ? styles.compact : null;
   gameLabel = gameLabel ?? (Object.values(GAMES).find(g => g.id.indexOf(data.gameId) > -1))?.name ?? "Game";
   const {
     userId,
@@ -34,22 +35,22 @@ const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false 
   const stakedAmount = Number.parseInt(stakedAmountRaw);
   const rewardAmount = Number.parseInt(rewardAmountRaw);
   return (
-    <div className={styles.messageItem}>
+    <div className={classNames(styles.messageItem, layoutCss)}>
       {type === 'lost' ? (
-        <Grid container>
+        <Grid container className={styles.flexContainer}>
           <Grid item xs>
             <div className={classNames(styles.messageFirst, styles.messageLeft)}>
               <p>{gameLabel}</p>
             </div>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <div className={styles.messageCenter}>
+            <div className={styles.messageLeft}>
               <p>{userId}</p>
             </div>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <div className={classNames(styles.messageCenter)}>
-              {toNumericString(stakedAmount)} {TOKEN_NAME}
+            <div className={classNames(styles.messageRight)}>
+              <p>{toNumericString(stakedAmount)} {TOKEN_NAME}</p>
               <img src={medalCoin} alt="medal" />
             </div>
           </Grid>
@@ -68,14 +69,14 @@ const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false 
           </Grid>
         </Grid>
       ) : (
-        <Grid container>
+        <Grid container className={styles.flexContainer}>
           <Grid item xs>
             <div className={classNames(styles.messageFirst, styles.messageLeft)}>
               <p>{gameLabel}</p>
             </div>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <div className={styles.messageCenter}>
+            <div className={styles.messageLeft}>
               <p>
                 {username ? (
                   <UserLink userId={userId} username={username} />
@@ -86,8 +87,8 @@ const ActivityTableRow = ({ data, type, gameLabel, hideSecondaryColumns = false 
             </div>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <div className={styles.messageCenter}>
-              {toNumericString(stakedAmount)} {TOKEN_NAME}
+            <div className={styles.messageRight}>
+              <p>{toNumericString(stakedAmount)} {TOKEN_NAME}</p>
               <img src={medalCoin} alt="medal" />
             </div>
           </Grid>

--- a/src/components/EventActivitiesTracker/index.js
+++ b/src/components/EventActivitiesTracker/index.js
@@ -83,8 +83,11 @@ const EventActivitiesTracker = ({
   userId,
   preselectedCategory,
   gameId,
-  hideSecondaryColumns = false
+  hideSecondaryColumns = false,
+  layout='compact'
 }) => {
+  const layoutCss = layout === 'compact' ? styles.compact : null;
+
   const messageListRef = useRef();
 
   const preselectCategory = preselectedCategory
@@ -185,7 +188,7 @@ const EventActivitiesTracker = ({
       }
 
       return (
-        <ActivityMessage key={index} activity={activityMessage} date={date} hideSecondaryColumns={hideSecondaryColumns}/>
+        <ActivityMessage key={index} activity={activityMessage} date={date} hideSecondaryColumns={hideSecondaryColumns} layout={layout}/>
       );
     });
   };
@@ -209,21 +212,21 @@ const EventActivitiesTracker = ({
   return (
     <div className={classNames(styles.activitiesTrackerContainer, className)}>
       <div className={styles.header}>
-        <Grid container>
+        <Grid container className={layoutCss}>
           <Grid item xs>
-            <p className={styles.titleFirst}>GAME</p>
+            <p className={styles.titleLeft}>GAME</p>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <p className={styles.title}>USER</p>
+            <p className={styles.titleLeft}>USER</p>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
-            <p className={styles.title}>TRADE</p>
+            <p className={styles.titleRight}>TRADE</p>
           </Grid>
           <Grid item xs className={hideSecondaryColumns && styles.hideSecondaryColumns}>
             <p className={styles.title}>MULT</p>
           </Grid>
           <Grid item xs>
-            <p className={styles.titleLast}>CASHOUT</p>
+            <p className={styles.titleRight}>CASHOUT</p>
           </Grid>
         </Grid>
       </div>

--- a/src/components/EventActivitiesTracker/styles.module.scss
+++ b/src/components/EventActivitiesTracker/styles.module.scss
@@ -18,12 +18,12 @@
     color: #878593;
     font-size: 12px;
   }
-  .titleFirst {
+  .titleLeft {
     text-align: left;
     font-size: 12px;
     color: #878593;
   }
-  .titleLast {
+  .titleRight {
     text-align: right;
     font-size: 12px;
     color: #878593;
@@ -37,7 +37,7 @@
     display: -webkit-box;
     margin-top: 0.5rem;
     font-size: 12px;
-    text-align: left;
+    //text-align: left;
     hyphens: auto;
     transition: opacity 300ms ease-out, transform 300ms ease-out;
     width: 100%;
@@ -250,6 +250,10 @@
   }
 }
 
+.flexContainer{
+  flex-wrap: nowrap !important;
+}
+
 .hideSecondaryColumns {
   display: none;
   @media (min-width: $screen-md) {
@@ -261,13 +265,36 @@
 .messageCenter,
 .messageRight,
 .title,
-.titleFirst,
-.titleLast {
-  white-space: nowrap;
-  padding: 4px 10px;
+.titleLeft,
+.titleRight {
+  padding:5px 15px;
   overflow-x: hidden;
 
   @media (max-width: $screen-xs) {
-    padding: 4px 0px;
+  padding: 2px 15px;
+  }
+
+  p{
+    text-align: right;
+  }
+}
+
+.compact{
+  .messageFirst,
+  .messageCenter,
+  .messageRight,
+  .title,
+  .titleLeft,
+  .titleRight {
+    max-width: 100px;
+    overflow:hidden ;
+    padding: 1px 3px;
+    @media (max-width: $screen-md) {
+      img {display:none;}
+    }
+    @media (max-width: $screen-xs) {
+
+      padding: 1px 3px;
+    }
   }
 }

--- a/src/components/SignUpPopup/index.js
+++ b/src/components/SignUpPopup/index.js
@@ -55,7 +55,7 @@ const SignUpPopup = ({ closed, user, hidePopup, showPopup, authState }) => {
   };
 
   return (
-    <div className={styles.welcomeContainer}>
+    <div className={styles.welcomeContainer} onClick={goToJoinPage}>
       <span className={styles.welcomeConfettiRight}>
         <Icon iconType={IconType.confettiRight} iconTheme={null} />
       </span>

--- a/src/screens/Activities/index.js
+++ b/src/screens/Activities/index.js
@@ -16,7 +16,7 @@ import './swiper.scss';
 import { Link } from 'react-router-dom';
 import Routes from 'constants/Routes';
 
-const Activities = () => {
+const Activities = ({showBets = false}) => {
   const dispatch = useDispatch();
 
   const [data24h, setData24h] = useState();
@@ -77,27 +77,31 @@ const Activities = () => {
         <div className={styles.container}>
           <div className={styles.globalStats}>
             <div className={styles.statsBlock}>
-              <div className={styles.statItem}>
-                <div className={styles.statItemHead}>
-                  <span>{toNumericString(data24h?.trades)}</span> 24h # of bets
+              {showBets && (
+                <>
+                <div className={styles.statItem}>
+                  <div className={styles.statItemHead}>
+                    <span>{toNumericString(data24h?.trades)}</span> 24h # of bets
+                  </div>
+                  {/*<div className={styles.statItemHint}>last 24 hours</div>*/}
                 </div>
-                {/*<div className={styles.statItemHint}>last 24 hours</div>*/}
-              </div>
-              <div className={styles.statItem}>
-                <div className={styles.statItemHead}>
-                  <span>{toNumericString(dataLastWeek?.trades)}</span> 7d # of
-                  bets
+                <div className={styles.statItem}>
+                  <div className={styles.statItemHead}>
+                    <span>{toNumericString(dataLastWeek?.trades)}</span> 7d # of
+                    bets
+                  </div>
+                  {/*<div className={styles.statItemHint}>last week</div>*/}
                 </div>
-                {/*<div className={styles.statItemHint}>last week</div>*/}
-              </div>
 
-              <div className={styles.statItem}>
-                <div className={styles.statItemHead}>
-                  <span>{toNumericString(dataAllTime?.trades)}</span> Total # of
-                  bets
+                <div className={styles.statItem}>
+                  <div className={styles.statItemHead}>
+                    <span>{toNumericString(dataAllTime?.trades)}</span> Total # of
+                    bets
+                  </div>
+                  {/*<div className={styles.statItemHint}>all time</div>*/}
                 </div>
-                {/*<div className={styles.statItemHint}>all time</div>*/}
-              </div>
+                </>
+              )}
 
               <div className={styles.statItem}>
                 <div className={styles.statItemHead}>
@@ -137,6 +141,7 @@ const Activities = () => {
               styles.activitiesTrackerContainerFull +
               ' activities-tracker-swiper'
             }
+            showBets={showBets}
           />
           {renderWallpaperBanner()}
         </div>

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -207,7 +207,7 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
                   <img src={howTokenWorkPToken} alt="" />
                 </div>
                 <div className={styles.detail}>
-                  <h3>$PFAIR Token?</h3>
+                  <h3>PFAIR Token?</h3>
                   <p>
                     PFAIR is Wallfair's FREE-TO-PLAY token. The tokens can be
                     used in the ALPACASINO playground for risk and care free
@@ -222,9 +222,9 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
                   <img src={howTokenWorkWToken} alt="" />
                 </div>
                 <div className={styles.detail}>
-                  <h3>$WFAIR Token?</h3>
+                  <h3>WFAIR Token?</h3>
                   <p>
-                    WFAIR tokens are your betting cryptocurrency, these are can
+                    WFAIR tokens are your betting cryptocurrency, these can be
                     transfered at anytime for real world cash
                   </p>
                 </div>
@@ -238,7 +238,7 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
                 <div className={styles.detail}>
                   <h3>WEEKLY Awards</h3>
                   <p>
-                    Keep playing and rise to the top of the leaderboard every week 
+                    Keep playing and rise to the top of the leaderboard every week
                     and increase the chances of winning real WFAIR tokens.
                     Winners will be announced every Sunday!
                   </p>
@@ -272,7 +272,7 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
                     Who is Alpacasino
                   </h3>
                   <p>
-                    Alpacasino is a new type of crypocurrency betting platform
+                    Alpacasino is a new type of cryptocurrency betting platform
                     which is more entertaining and easier than any other
                     platform out there!
                   </p>
@@ -306,9 +306,9 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
                   <img src={whoWeAreCard3} alt="" />
                 </div>
                 <div className={styles.detail}>
-                  <h3>Competive Edge</h3>
+                  <h3>Competitive Edge</h3>
                   <p>
-                    More you win the higher you climb the monthly community
+                    The more you win the higher you climb the monthly community
                     leaderboards. We’ve added some secret challenges to reward
                     you even more $PFAIR Tokens ...
                   </p>

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -74,7 +74,7 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
         refreshLuckyData();
         break;
       case 3:
-        if(userId) refreshMyBetsData({userId});
+        if(userId) refreshMyBetsData({userId: '6152b82b2a1ac4fa41b4c663'});
         break;
     }
     setActivityTabIndex(index);
@@ -93,7 +93,7 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
   useEffect(() => {
     refreshHighData();
     refreshLuckyData();
-    if(userId) refreshMyBetsData({userId});
+    if(userId) refreshMyBetsData({userId: '6152b82b2a1ac4fa41b4c663'});
   }, [dispatch, connected]);
 
   const renderBetApprovePopup = async () => {
@@ -380,12 +380,14 @@ const Home = ({ tags, setOpenDrawer, fetchTags, showPopup, events, refreshHighDa
                   className={styles.activitiesTrackerGamesBlock}
                   preselectedCategory={'game'}
                   hideSecondaryColumns={true}
+                  layout='wide'
                 />
               )}
               {activityTabIndex !== 0 && (
                 <ActivityTable
                   hideSecondaryColumns={true}
                   rowData={getActivityTableData()}
+                  layout='wide'
                 />
               )}
             </div>


### PR DESCRIPTION
- Desktop: Constant scrollbar at the bottom even though you cannot scroll horizontally
-  Mobile: "Join now" popup: The hitbox of the button is not aligned with the button (you must tap on the left side to open the sign up)
- Home without login: PFAIR and WFAIR have $ in front ($PFAIR and $WFAIR)
- Home without login: Typo in "Who is Alpacasino" ("crypocurrency" instead of "cryptocurrency")
- Home without login: Typo in "Competive Edge" ("Competive" instead of "Competitive")
- Home without login: Typo in "Competive Edge" (First sentence should be "The more you win, the higher [...]")
- Home without login: Typo in "$WFAIR Token?" ("these are can transfered" should be "these can be transferred")
- Mobile: Home: Activities: Cashout column is too big (Cashout headline is right-aligned but the cashed out tokens are on the left)
- Home: Activities: My Bets: The Cashout is always green and is different from "All" tab (if you hit 0 on Wheel, "All" shows in red -bet value but "My Bets" shows 0 PFAIR in green)
- Activities: Tab "Bets" not needed without Events
- Sign up: Age checker: Only the year is used to check if someone is 18 (for example 24th of December 2003 is allowed even though you are 17)